### PR TITLE
Fix run_hf.py and plot_accuracy.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,30 @@
-scripts/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Unit test / coverage reports
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+
+# Environments
+.env
+.venv
 venv/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# VSCode
+.vscode/
+.python-version
+
+# Model cache and Results
 cache/
 results/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 scripts/
+venv/
+cache/
+results/

--- a/evaluation/plot_accuracy.py
+++ b/evaluation/plot_accuracy.py
@@ -1,31 +1,96 @@
-EXPERIMENTS_ARTIFACT = [PromptType.normal, PromptType.artifact_choices]
-EXPERIMENTS_MEMORIZE = [PromptType.normal, PromptType.memorization_empty, PromptType.memorization_gold, PromptType.memorization_no_choice]
-EXPERIMENTS_INFER_QUESTION = EXPERIMENTS_ARTIFACT + [PromptType.artifact_choices_cot_twostep_generated, PromptType.artifact_choices_cot_twostep_random]
-
-# set experiments to one of the lists above
-EXPERIMENTS = ... 
-# set absolute prefix for results folder
-res_prefix = ...
-# output directory of the plot
-out_dir = ...
-
-import sys
 import datasets
+import argparse
 import pickle
-import os
 import numpy as np
-import pickle
 import pandas as pd
 from scipy import stats
-import numpy as np
 import matplotlib.pyplot as plt
+import sys
+import os
 
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'model'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'model'))
 
-from data_loader import create_data_evaluation
-from data_loader import PromptType, DatasetName
+from data_loader import create_data_evaluation, PromptType, DatasetName, ModelName
 
-DATASETS = [DatasetName.ARC, DatasetName.mmlu, DatasetName.HellaSwag]
+EXPERIMENTS_ARTIFACT = [PromptType.normal, PromptType.artifact_choices]
+EXPERIMENTS_MEMORIZE = [
+    PromptType.normal, PromptType.memorization_empty,
+    PromptType.memorization_gold, PromptType.memorization_no_choice
+]
+EXPERIMENTS_INFER_QUESTION = EXPERIMENTS_ARTIFACT + [
+    PromptType.artifact_choices_cot_twostep_generated, PromptType.artifact_choices_cot_twostep_random
+]
+
+
+def setup():
+    def enum_type(enum):
+        enum_members = {e.name: e for e in enum}
+
+        def converter(input):
+            out = []
+            for x in input.split():
+                if x in enum_members:
+                    out.append(enum_members[x])
+                else:
+                    raise argparse.ArgumentTypeError(
+                        f"You used {x}, but value must be one of {', '.join(enum_members.keys())}"
+                    )
+            return out
+
+        return converter
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--models",
+        '-m',
+        type=enum_type(ModelName),
+        help="(Nick)name of models",
+        default=[ModelName.llama_7b, ModelName.falcon_40b, ModelName.mistral_7b, ModelName.phi_2]
+    )
+    parser.add_argument(
+        "--datasets",
+        type=enum_type(DatasetName),
+        help="Name of the dataset (in dataset_name column)",
+        default=[DatasetName.ARC, DatasetName.mmlu, DatasetName.HellaSwag]
+    )
+    parser.add_argument(
+        '--experiments',
+        type=str,
+        help='experiments to run',
+        default="artifact",
+        choices=["artifact", "memorization", "inference"]
+    )
+    parser.add_argument(
+        "--res_dir",
+        type=str,
+        help="Absolute directory of the output results folder",
+        default="/mcqa-artifacts/results"
+    )
+    parser.add_argument(
+        "--plot_dir",
+        type=str,
+        help="Absolute directory of folder for saving plots",
+        default="/mcqa-artifacts/images"
+    )
+
+    args = parser.parse_args()
+
+    args.models = [model.value for model in args.models]
+
+    if args.experiments == "artifact":
+        args.experiments = EXPERIMENTS_ARTIFACT
+    elif args.experiments == "memorization":
+        args.experiments = EXPERIMENTS_MEMORIZE
+    elif args.experiments == "inference":
+        args.experiments = EXPERIMENTS_INFER_QUESTION
+
+    print("models:", args.models)
+    print("experiments:", [experiment.value for experiment in args.experiments])
+    print("datasets:", [dataset.value for dataset in args.datasets])
+
+    return args
+
+
 t_test_strats = {}
 
 colors = {
@@ -60,29 +125,31 @@ pt_names_map = {
 }
 
 model_names_map = {
-    'llama 70b': 'LLaMA 70B',
-    'llama 13b': 'LLaMA 13B',
-    'llama 7b': 'LLaMA 7B',
-    'falcon 40b': 'Falcon 40B',
-    'mistral 7b': 'Mixtral 8x7B',
-    'phi 2': 'Phi 2'
+    'llama_70b': 'LLaMA 70B',
+    'llama_13b': 'LLaMA 13B',
+    'llama_7b': 'LLaMA 7B',
+    'falcon_40b': 'Falcon 40B',
+    'mistral_7b': 'Mixtral 8x7B',
+    'phi_2': 'Phi 2'
 }
 
 patterns = {
     PromptType.artifact_choices_cot_twostep_generated.value: '///',
 }
 
-bar_width = 0.3 if len(EXPERIMENTS) == 2 else 0.2
-legend_margin = 0.22 # higher is more space
-p_value_cutoff = 0.00005
-if res_prefix[-1] != '/':
-    res_prefix += '/'
 
-MODELS = ['llama 70b', 'falcon 40b', 'mistral 7b', 'phi 2']
+reported_res = {
+    'llama_7b': {
+        DatasetName.ARC: 0.5307, DatasetName.HellaSwag: 0.7859, DatasetName.mmlu: 0.3876, DatasetName.Winogrande: 0.7403
+    },
+    'llama_13b': {
+        DatasetName.ARC: 0.5939, DatasetName.HellaSwag: 0.8213, DatasetName.mmlu: 0.5577, DatasetName.Winogrande: 0.7664
+    },
+    'llama_70b': {
+        DatasetName.ARC: 0.6732, DatasetName.HellaSwag: 0.8733, DatasetName.mmlu: 0.6983, DatasetName.Winogrande: 0.8374
+    }
+}
 
-reported_res = {'llama 7b': {DatasetName.ARC: 0.5307, DatasetName.HellaSwag: 0.7859, DatasetName.mmlu: 0.3876, DatasetName.Winogrande: 0.7403},
-                'llama 13b': {DatasetName.ARC: 0.5939, DatasetName.HellaSwag: 0.8213, DatasetName.mmlu: 0.5577, DatasetName.Winogrande: 0.7664},
-                'llama 70b': {DatasetName.ARC: 0.6732, DatasetName.HellaSwag: 0.8733, DatasetName.mmlu: 0.6983, DatasetName.Winogrande: 0.8374}}
 
 def format_models(models):
     models_ = []
@@ -97,6 +164,7 @@ def format_models(models):
             models_.append(m)
     return models_
 
+
 def format_dataset(ds):
     if ds == DatasetName.mmlu:
         return 'MMLU (5-shot)'
@@ -107,12 +175,11 @@ def format_dataset(ds):
     else:
         return ds.value
 
-ds = datasets.load_dataset('nbalepur/mcqa_artifacts')
 
 def convert_raw_text(rt):
-    if rt == None:
+    if rt is None:
         return 'Z'
-    rt_old = rt
+    # rt_old = rt   # unused
     if 'Answer:' in rt:
         rt = rt[rt.index('Answer:') + len('Answer:'):]
     rt = rt[:4]
@@ -124,18 +191,9 @@ def convert_raw_text(rt):
     if rt in {'(3)', '(C)'}:
         return 'C'
     if rt in {'(D)', '(4)'}:
-        return 'D' 
+        return 'D'
     return 'Z'
 
-fig, axs_ = plt.subplots(1, 3, figsize=(14, 3))
-try:
-    axs = list(axs_.ravel())
-except:
-    axs = [axs_]
-    axs_ = [[axs_]]
-idx_ = 0
-
-random_guess_accuracy, majority_accuracy = dict(), dict()
 
 def get_llm_answer(prompt, answer, choices_true):
     prompt = prompt.split('\n\n')[-1]    
@@ -144,6 +202,7 @@ def get_llm_answer(prompt, answer, choices_true):
     if ord(answer) - ord('A') >= len(choices):
         return ''
     return choices[ord(answer) - ord('A')]
+
 
 def compute_accuracy(p, t):
     arr = []
@@ -155,117 +214,143 @@ def compute_accuracy(p, t):
             arr.append(int(p_ == t_))
     return np.mean(arr), arr
 
-for dataset_idx, dataset in enumerate(DATASETS):
 
-    benchmark_graph_data = {'LLM': [], 'Strategy': [], 'Accuracy': []}
-    arr_map = dict()
+if __name__ == '__main__':
+    args = setup()
+    ds = datasets.load_dataset('nbalepur/mcqa_artifacts')
 
-    for model_nickname in MODELS:
+    fig, axs_ = plt.subplots(1, 3, figsize=(14, 3))
+    bar_width = 0.3 if len(args.experiments) == 2 else 0.2
+    legend_margin = 0.22  # higher is more space
+    p_value_cutoff = 0.00005
+    try:
+        axs = list(axs_.ravel())
+    except:
+        axs = [axs_]
+        axs_ = [[axs_]]
+    idx_ = 0
 
-        for pt in EXPERIMENTS:
-            data = create_data_evaluation(ds, dataset, pt)
-            questions, choices, answer_letters, answer_texts = data['questions'], data['choices'], data['answer_letters'], data['answer_texts']
+    random_guess_accuracy, majority_accuracy = dict(), dict()
 
-            if dataset not in majority_accuracy:
-                freq = dict()
-                for a in answer_letters:
-                    freq[a] = freq.get(a, 0) + 1
-                v = list(freq.values())
-                max_item = max(freq.items(), key = lambda item: item[1])[0]
-                majority_arr_ = [max_item for _ in range(len(questions))]
-                majority_arr = [int(majority_arr_[m_idx] == answer_letters[m_idx]) for m_idx in range(len(majority_arr_))]
-                majority_accuracy[dataset] = max(v) / sum(v)
+    for dataset_idx, dataset in enumerate(args.datasets):
+        benchmark_graph_data = {'LLM': [], 'Strategy': [], 'Accuracy': []}
+        arr_map = dict()
 
-            res_dir = f'{res_prefix}{dataset.value}/{model_nickname}/{pt.value}.pkl'
-            with open(res_dir, 'rb') as handle:
-                res = pickle.load(handle)
+        for model_nickname in args.models:
+            for pt in args.experiments:
+                data = create_data_evaluation(ds, dataset, pt)
+                questions, choices, answer_letters, answer_texts = data['questions'], data['choices'], data['answer_letters'], data['answer_texts']
 
-            pred_answer_letters = [convert_raw_text(rt) for rt in res['raw_text']]
-            orig_pred, orig_true = len(pred_answer_letters), len(answer_letters)
-            if PromptType.artifact_choices_cot_twostep_generated in EXPERIMENTS and dataset == DatasetName.mmlu:
-                valid_idxs = set(range(int(0.75 * orig_true)))
-            else:
-                valid_idxs = set(range(orig_true))
+                if dataset not in majority_accuracy:
+                    freq = dict()
+                    for a in answer_letters:
+                        freq[a] = freq.get(a, 0) + 1
+                    v = list(freq.values())
+                    max_item = max(freq.items(), key=lambda item: item[1])[0]
+                    majority_arr_ = [max_item for _ in range(len(questions))]
+                    majority_arr = [int(majority_arr_[m_idx] == answer_letters[m_idx]) for m_idx in range(len(majority_arr_))]
+                    majority_accuracy[dataset] = max(v) / sum(v)
 
-            pred_answer_letters = [pred_answer_letters[idx] for idx in range(len(pred_answer_letters))]
+                res_dir = f'{args.res_dir}/{dataset.value}/{model_nickname}/{pt.value}.pkl'
+                with open(res_dir, 'rb') as handle:
+                    res = pickle.load(handle)
 
-            pred_idx = [ord(l) for l in pred_answer_letters]
-            true_idx = [ord(l) for l in answer_letters]
+                pred_answer_letters = [convert_raw_text(rt) for rt in res['raw_text']]
+                orig_pred, orig_true = len(pred_answer_letters), len(answer_letters)
+                if PromptType.artifact_choices_cot_twostep_generated in args.experiments and dataset == DatasetName.mmlu:
+                    valid_idxs = set(range(int(0.75 * orig_true)))
+                else:
+                    valid_idxs = set(range(orig_true))
 
-            true_idx = [true_idx[idx] for idx in valid_idxs]
-            pred_idx = [pred_idx[idx] for idx in valid_idxs]
+                pred_answer_letters = [pred_answer_letters[idx] for idx in range(len(pred_answer_letters))]
 
-            assert(len(pred_idx) == len(true_idx))
+                pred_idx = [ord(letter) for letter in pred_answer_letters]
+                true_idx = [ord(letter) for letter in answer_letters]
 
-            accuracy, arr = compute_accuracy(pred_idx, true_idx)
-            arr_map[(model_nickname, pt.value)] = arr
+                true_idx = [true_idx[idx] for idx in valid_idxs]
+                pred_idx = [pred_idx[idx] for idx in valid_idxs]
 
-            benchmark_graph_data['Accuracy'].append(accuracy)
-            benchmark_graph_data['LLM'].append(model_names_map[model_nickname])
-            benchmark_graph_data['Strategy'].append(pt.value)
+                assert len(pred_idx) == len(true_idx)
 
-     
-    df = pd.DataFrame(benchmark_graph_data)
-    df['Strategy'] = pd.Categorical(df['Strategy'], categories=[e.value for e in EXPERIMENTS], ordered=True) #+ ['reported']
-    df['LLM'] = pd.Categorical(df['LLM'], categories=[model_names_map[m] for m in MODELS], ordered=True)
+                accuracy, arr = compute_accuracy(pred_idx, true_idx)
+                arr_map[(model_nickname, pt.value)] = arr
 
-    ax = axs[idx_]
-    idx_ += 1
+                benchmark_graph_data['Accuracy'].append(accuracy)
+                benchmark_graph_data['LLM'].append(model_names_map[model_nickname])
+                benchmark_graph_data['Strategy'].append(pt.value)
 
-    offset = 0
-    
-    llm_positions = list(range(len(MODELS)))
-    relative_positions = list(0 + np.arange(len(EXPERIMENTS) + 1))
+        df = pd.DataFrame(benchmark_graph_data)
+        df['Strategy'] = pd.Categorical(df['Strategy'], categories=[e.value for e in args.experiments], ordered=True) #+ ['reported']
+        df['LLM'] = pd.Categorical(df['LLM'], categories=[model_names_map[m] for m in args.models], ordered=True)
 
+        ax = axs[idx_]
+        idx_ += 1
 
-    #ax.axhline(random_guess_accuracy[dataset], color='orange', linewidth=2, label='Guessing', ls='--')
-    ax.axhline(majority_accuracy[dataset], color='orange', linewidth=2, label='Majority Class', ls='--')
+        offset = 0
 
-    for idx, strategy in enumerate(df['Strategy'].unique()):
-        accuracies = df[df['Strategy'] == strategy]['Accuracy'].values
-        bars = ax.bar([pos + relative_positions[idx]*bar_width for pos in llm_positions], accuracies, bar_width, 
-                    label=pt_names_map[strategy], color=colors_map[strategy], hatch=patterns.get(strategy, ''))
-        
-        if strategy in t_test_strats:
-            for bar_idx in range(len(bars)):
-                bar_offset = 0.02
-                t_test = stats.ttest_ind(arr_map[(MODELS[bar_idx], strategy)], majority_arr, alternative='greater')
-                
-                if t_test.pvalue < p_value_cutoff:
-                    ax.text(bars[bar_idx].xy[0] + 0.5 * bar_width, bars[bar_idx].xy[1] + bars[bar_idx]._height + bar_offset, '*', fontsize=12, fontweight='semibold', verticalalignment='center', horizontalalignment='center')
-        
-        
-    ax.set_title(f'{format_dataset(dataset)}')
-    ax.set_xticks(np.array(llm_positions) + (len(EXPERIMENTS) * 0.5) * bar_width - 0.5 * bar_width)
-    ax.set_xticklabels([m for m in df['LLM'].unique()])
-    ax.set_ylim(top=1.0)
-    ax.set_ylim(bottom=0)
+        llm_positions = list(range(len(args.models)))
+        relative_positions = list(0 + np.arange(len(args.experiments) + 1))
 
-    if dataset_idx % 2 == 0:
-        ax.set_ylabel('Accuracy')
+        # ax.axhline(random_guess_accuracy[dataset], color='orange', linewidth=2, label='Guessing', ls='--')
+        ax.axhline(majority_accuracy[dataset], color='orange', linewidth=2, label='Majority Class', ls='--')
 
-all_handles = []
-all_labels = []
+        for idx, strategy in enumerate(df['Strategy'].unique()):
+            accuracies = df[df['Strategy'] == strategy]['Accuracy'].values
+            bars = ax.bar(
+                [pos + relative_positions[idx]*bar_width for pos in llm_positions],
+                accuracies,
+                bar_width,
+                label=pt_names_map[strategy],
+                color=colors_map[strategy],
+                hatch=patterns.get(strategy, '')
+            )
 
-if type(axs_[0]) == type([]):
-    for ax in axs_:
-        for a in ax:
+            if strategy in t_test_strats:
+                for bar_idx in range(len(bars)):
+                    bar_offset = 0.02
+                    t_test = stats.ttest_ind(arr_map[(args.models[bar_idx], strategy)], majority_arr, alternative='greater')
+
+                    if t_test.pvalue < p_value_cutoff:
+                        ax.text(
+                            bars[bar_idx].xy[0] + 0.5 * bar_width, bars[bar_idx].xy[1] + bars[bar_idx]._height + bar_offset,
+                            '*',
+                            fontsize=12,
+                            fontweight='semibold',
+                            verticalalignment='center',
+                            horizontalalignment='center'
+                        )
+
+        ax.set_title(f'{format_dataset(dataset)}')
+        ax.set_xticks(np.array(llm_positions) + (len(args.experiments) * 0.5) * bar_width - 0.5 * bar_width)
+        ax.set_xticklabels([m for m in df['LLM'].unique()])
+        ax.set_ylim(top=1.0)
+        ax.set_ylim(bottom=0)
+
+        if dataset_idx % 2 == 0:
+            ax.set_ylabel('Accuracy')
+
+    all_handles = []
+    all_labels = []
+
+    if isinstance(axs_[0], list):
+        for ax in axs_:
+            for a in ax:
+                h, l = a.get_legend_handles_labels()
+                all_handles.extend(h)
+                all_labels.extend(l)
+    else:
+        for a in axs_:
             h, l = a.get_legend_handles_labels()
             all_handles.extend(h)
             all_labels.extend(l)
-else:
-    for a in axs_:
-        h, l = a.get_legend_handles_labels()
-        all_handles.extend(h)
-        all_labels.extend(l)
 
+    # To ensure that the legend is unique
+    unique = [(h, l) for i, (h, l) in enumerate(zip(all_handles, all_labels)) if l not in all_labels[:i]]
+    unique_handles, unique_labels = zip(*unique)
 
-# To ensure that the legend is unique
-unique = [(h, l) for i, (h, l) in enumerate(zip(all_handles, all_labels)) if l not in all_labels[:i]]
-unique_handles, unique_labels = zip(*unique)
+    fig.legend(unique_handles, unique_labels, fontsize=12, loc='lower center', ncol=5)
 
-fig.legend(unique_handles, unique_labels, fontsize=12, loc='lower center', ncol=5)
-
-plt.tight_layout()
-plt.subplots_adjust(bottom=legend_margin)
-plt.savefig(out_dir, dpi=500)
+    plt.tight_layout()
+    plt.subplots_adjust(bottom=legend_margin)
+    print(f"Saving accuracy plot to {args.plot_dir}/plot_accuracy.png")
+    plt.savefig(os.path.join(args.plot_dir, "plot_accuracy.png"), dpi=500)

--- a/evaluation/plot_accuracy.py
+++ b/evaluation/plot_accuracy.py
@@ -45,7 +45,7 @@ def setup():
         '-m',
         type=enum_type(ModelName),
         help="(Nick)name of models",
-        default=[ModelName.llama_7b, ModelName.falcon_40b, ModelName.mistral_7b, ModelName.phi_2]
+        default=[]
     )
     parser.add_argument(
         "--datasets",
@@ -71,6 +71,13 @@ def setup():
         type=str,
         help="Absolute directory of folder for saving plots",
         default="/mcqa-artifacts/images"
+    )
+    parser.add_argument(
+        "--plot_file_name",
+        "-f",
+        type=str,
+        help="Name of the plot file",
+        default="accuracy.png"
     )
 
     args = parser.parse_args()
@@ -130,7 +137,11 @@ model_names_map = {
     'llama_7b': 'LLaMA 7B',
     'falcon_40b': 'Falcon 40B',
     'mistral_7b': 'Mixtral 8x7B',
-    'phi_2': 'Phi 2'
+    'phi_2': 'Phi 2',
+    'pythia_1_4b': 'Pythia 1.4b',
+    'pythia_2_8b': 'Pythia 2.8b',
+    'pythia_6_9b': 'Pythia 6.9b',
+    'pythia_12b': 'Pythia 12b'
 }
 
 patterns = {
@@ -239,7 +250,8 @@ if __name__ == '__main__':
         for model_nickname in args.models:
             for pt in args.experiments:
                 data = create_data_evaluation(ds, dataset, pt)
-                questions, choices, answer_letters, answer_texts = data['questions'], data['choices'], data['answer_letters'], data['answer_texts']
+                questions, choices, answer_letters, answer_texts = \
+                    data['questions'], data['choices'], data['answer_letters'], data['answer_texts']
 
                 if dataset not in majority_accuracy:
                     freq = dict()
@@ -248,7 +260,8 @@ if __name__ == '__main__':
                     v = list(freq.values())
                     max_item = max(freq.items(), key=lambda item: item[1])[0]
                     majority_arr_ = [max_item for _ in range(len(questions))]
-                    majority_arr = [int(majority_arr_[m_idx] == answer_letters[m_idx]) for m_idx in range(len(majority_arr_))]
+                    majority_arr = \
+                        [int(majority_arr_[m_idx] == answer_letters[m_idx]) for m_idx in range(len(majority_arr_))]
                     majority_accuracy[dataset] = max(v) / sum(v)
 
                 res_dir = f'{args.res_dir}/{dataset.value}/{model_nickname}/{pt.value}.pkl'
@@ -280,7 +293,7 @@ if __name__ == '__main__':
                 benchmark_graph_data['Strategy'].append(pt.value)
 
         df = pd.DataFrame(benchmark_graph_data)
-        df['Strategy'] = pd.Categorical(df['Strategy'], categories=[e.value for e in args.experiments], ordered=True) #+ ['reported']
+        df['Strategy'] = pd.Categorical(df['Strategy'], categories=[e.value for e in args.experiments], ordered=True)  # + ['reported']
         df['LLM'] = pd.Categorical(df['LLM'], categories=[model_names_map[m] for m in args.models], ordered=True)
 
         ax = axs[idx_]
@@ -352,5 +365,5 @@ if __name__ == '__main__':
 
     plt.tight_layout()
     plt.subplots_adjust(bottom=legend_margin)
-    print(f"Saving accuracy plot to {args.plot_dir}/plot_accuracy.png")
-    plt.savefig(os.path.join(args.plot_dir, "plot_accuracy.png"), dpi=500)
+    print(f"Saving accuracy plot to {args.plot_dir}/{args.plot_file_name}")
+    plt.savefig(os.path.join(args.plot_dir, args.plot_file_name), dpi=500)

--- a/model/data_loader.py
+++ b/model/data_loader.py
@@ -63,6 +63,10 @@ class ModelName(Enum):
     falcon_40b = 'falcon_40b'
     mistral_7b = 'mistral_7b'
     phi_2 = 'phi_2'
+    pythia_1_4b = 'pythia_1_4b'
+    pythia_2_8b = 'pythia_2_8b'
+    pythia_6_9b = 'pythia_6_9b'
+    pythia_12b = 'pythia_12b'
 
 
 prompt_type_map = {

--- a/model/data_loader.py
+++ b/model/data_loader.py
@@ -42,10 +42,10 @@ class PromptType(Enum):
 
 
 class DatasetName(Enum):
-    mmlu = 'mmlu' # MMLU
-    HellaSwag = 'HellaSwag' # HellaSwag
-    ARC = 'ARC' # ARC
-    Winogrande = 'Winogrande' # Winogrande (not in paper)
+    mmlu = 'mmlu'  # MMLU
+    HellaSwag = 'HellaSwag'  # HellaSwag
+    ARC = 'ARC'  # ARC
+    Winogrande = 'Winogrande'  # Winogrande (not in paper)
 
 # class DatasetName(Enum):
 #     ARC = 'ARC'
@@ -54,6 +54,16 @@ class DatasetName(Enum):
 #     PIQA = 'PIQA'
 #     QASC = 'QASC'
 #     SIQA = 'SIQA'
+
+
+class ModelName(Enum):
+    llama_70b = 'llama_70b'
+    llama_13b = 'llama_13b'
+    llama_7b = 'llama_7b'
+    falcon_40b = 'falcon_40b'
+    mistral_7b = 'mistral_7b'
+    phi_2 = 'phi_2'
+
 
 prompt_type_map = {
     PromptType.normal: Normal,

--- a/model/run_hf.py
+++ b/model/run_hf.py
@@ -1,5 +1,5 @@
 # imports and directory setup
-from data_loader import create_data, DatasetName, PromptType
+from data_loader import create_data, DatasetName, ModelName, PromptType
 
 import datasets
 from huggingface_hub.hf_api import HfFolder
@@ -36,9 +36,9 @@ def setup():
     parser.add_argument(
         "--model_name",
         '-m',
-        type=str,
+        type=enum_type(ModelName),
         help="(Nick)name of the model in directory",
-        default="llama 7b",
+        default=ModelName.llama_7b
     )
     parser.add_argument(
         "--model_name_hf",

--- a/model/run_hf_remote.py
+++ b/model/run_hf_remote.py
@@ -1,21 +1,16 @@
 # imports and directory setup
 from data_loader import create_data, DatasetName, PromptType
 
-import pickle
 import datasets
-import json
-from transformers import pipeline
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM
-import transformers
+from huggingface_hub.hf_api import HfFolder
+from transformers import AutoTokenizer, AutoModelForCausalLM, StoppingCriteria, StoppingCriteriaList
 import torch
 import tqdm
 import os
-import copy
-from transformers import AutoTokenizer
-from huggingface_hub.hf_api import HfFolder
+import pickle
 
 # =========================================== Argument Setup ===========================================
+
 
 def setup():
 
@@ -28,7 +23,9 @@ def setup():
                 if x in enum_members:
                     out.append(enum_members[x])
                 else:
-                    raise argparse.ArgumentTypeError(f"You used {x}, but value must be one of {', '.join(enum_members.keys())}")
+                    raise argparse.ArgumentTypeError(
+                        f"You used {x}, but value must be one of {', '.join(enum_members.keys())}"
+                    )
             return out
 
         return converter
@@ -51,28 +48,24 @@ def setup():
     )
     parser.add_argument(
         "--dataset_name",
-        nargs='*',
         type=enum_type(DatasetName),
         help="Name of the dataset (in dataset_name column)",
         default=[],
     )
     parser.add_argument(
         "--train_dataset_split",
-        nargs='*',
         type=str,
         help="Training dataset split",
         default="",
     )
     parser.add_argument(
         "--eval_dataset_split",
-        nargs='*',
         type=str,
         help="Evaluation dataset split",
         default="",
     )
     parser.add_argument(
         "--hf_dataset_name",
-        nargs='*',
         type=str,
         help="Name of the dataset on huggingface",
         default="",
@@ -96,10 +89,9 @@ def setup():
         default="",
     )
     parser.add_argument(
-        '--prompt_types', 
-        nargs='*', 
-        type=enum_type(PromptType), 
-        help='Prompt types/experiments to run', 
+        '--prompt_types',
+        type=enum_type(PromptType),
+        help='Prompt types/experiments to run',
         default=[]
     )
     parser.add_argument(
@@ -139,7 +131,7 @@ def setup():
     load_in_8bit = (args.load_in_8bit == 'True')
     use_20_fewshot = (args.use_20_fewshot == 'True')
 
-    assert(not (load_in_4bit and load_in_8bit))
+    assert not (load_in_4bit and load_in_8bit)
 
     dataset_names = args.dataset_name
     dataset_split = (args.train_dataset_split, args.eval_dataset_split)
@@ -152,14 +144,29 @@ def setup():
     hf_token = args.hf_token
     HfFolder.save_token(hf_token)
 
-    return dataset_names, dataset_split, hf_dataset_name, prompt_types, model_name, hf_model_name, load_in_4bit, load_in_8bit, use_20_fewshot, partition, args.prompt_dir, args.res_dir, args.cache_dir
+    return (
+        dataset_names,
+        dataset_split,
+        hf_dataset_name,
+        prompt_types,
+        model_name,
+        hf_model_name,
+        load_in_4bit,
+        load_in_8bit,
+        use_20_fewshot,
+        partition,
+        args.prompt_dir,
+        args.res_dir,
+        args.cache_dir
+    )
 
 # =========================================== Load Model ===========================================
+
 
 def load_model(hf_model_name, load_in_4bit, load_in_8bit, cache_dir):
 
     # load tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(hf_model_name, cache_dir = cache_dir, trust_remote_code = True)
+    tokenizer = AutoTokenizer.from_pretrained(hf_model_name, cache_dir=cache_dir, trust_remote_code=True)
 
     # set up pipeline
     dtype = {
@@ -169,21 +176,22 @@ def load_model(hf_model_name, load_in_4bit, load_in_8bit, cache_dir):
             "auto": "auto",
     }['auto']
 
-    model = AutoModelForCausalLM.from_pretrained(hf_model_name, 
-                                                 torch_dtype=dtype,
-                                                 device_map="cuda",
-                                                 trust_remote_code=True,
-                                                 load_in_4bit=load_in_4bit,
-                                                 load_in_8bit=load_in_8bit,
-                                                 cache_dir=cache_dir)
+    model = AutoModelForCausalLM.from_pretrained(
+        hf_model_name,
+        torch_dtype=dtype,
+        device_map="cuda",
+        trust_remote_code=True,
+        load_in_4bit=load_in_4bit,
+        load_in_8bit=load_in_8bit,
+        cache_dir=cache_dir
+    )
 
     return model, tokenizer
 
-import torch
-from transformers import StoppingCriteria, StoppingCriteriaList
+
 class StoppingCriteriaSub(StoppingCriteria):
 
-    def __init__(self, stop_tokens = [], prompt_len = 0):
+    def __init__(self, stop_tokens=[], prompt_len=0):
         super().__init__()
         self.prompt_len = prompt_len
         self.stop_tokens = stop_tokens
@@ -194,30 +202,47 @@ class StoppingCriteriaSub(StoppingCriteria):
         seq_in_gen = sublist in [input_ids[i:len(sublist)+i] for i in range(self.prompt_len, len(input_ids))]
         return seq_in_gen
 
-def generate_text(prompt, stop_token):
+
+def generate_text(model, tokenizer, prompt, stop_token):
     input_ids = tokenizer.encode(prompt, return_tensors='pt')
     inputs = tokenizer(prompt, return_tensors='pt', return_attention_mask=False).to('cuda')
-    stopping_criteria = StoppingCriteriaList([StoppingCriteriaSub(tokenizer(stop_token).input_ids[2:], prompt_len=input_ids.shape[1])])
-    outputs = model.generate(**inputs,
-                             min_new_tokens=5,
-                             max_new_tokens=200,
-                             do_sample=False,
-                             stopping_criteria=stopping_criteria,
-                             ).to('cpu').detach()
+    stopping_criteria = StoppingCriteriaList(
+        [StoppingCriteriaSub(tokenizer(stop_token).input_ids[2:], prompt_len=input_ids.shape[1])]
+    )
+    outputs = model.generate(
+        **inputs,
+        min_new_tokens=5,
+        max_new_tokens=200,
+        do_sample=False,
+        stopping_criteria=stopping_criteria
+    ).to('cpu').detach()
     response = tokenizer.batch_decode(outputs[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)[0]
     return response[:-len(stop_token)].strip()
 
-def run_inference(dataset_names, dataset_split, hf_dataset_name, prompt_types, model_name, partition, use_20_fewshot, pipe, tokenizer, prompt_dir, res_dir):
+
+def run_inference(
+    dataset_names,
+    dataset_split,
+    hf_dataset_name,
+    prompt_types,
+    model_name,
+    partition,
+    use_20_fewshot,
+    model,
+    tokenizer,
+    prompt_dir,
+    res_dir
+):
 
     # load data
     ds = datasets.load_dataset(hf_dataset_name)
 
-    for dataset_name in dataset_names[0]:
+    for dataset_name in dataset_names:
 
         # results directory setup
-        results_dir = f'{res_dir}{dataset_name.value}/{model_name}'
+        results_dir = f'{res_dir}/{dataset_name.value}/{model_name}'
 
-        for pt in prompt_types[0]:
+        for pt in prompt_types:
             data = create_data(ds, dataset_name, dataset_split, pt, prompt_dir, use_20_fewshot=use_20_fewshot)
             input_prompts, output_letters, stop_token = data['input'], data['output'], data['stop_token']
 
@@ -243,8 +268,8 @@ def run_inference(dataset_names, dataset_split, hf_dataset_name, prompt_types, m
             start, end = partition_map[partition]
 
             for i in tqdm.tqdm(range(start, end)):
-                prompt = input_prompts[i] # get prompt
-                out_text = generate_text(prompt, stop_token) # generate output
+                prompt = input_prompts[i]  # get prompt
+                out_text = generate_text(model, tokenizer, prompt, stop_token)  # generate output
                 if i == len(input_prompts)-1:
                     print('done generating!', flush=True)
                 answers['raw_text'].append(out_text)
@@ -255,19 +280,33 @@ def run_inference(dataset_names, dataset_split, hf_dataset_name, prompt_types, m
                 final_res_dir = f'{results_dir}/{pt.value}_{partition}.pkl'
             else:
                 final_res_dir = f'{results_dir}/{pt.value}.pkl'
-                
+
             if not os.path.exists('/'.join(final_res_dir.split('/')[:-1])):
                 os.makedirs('/'.join(final_res_dir.split('/')[:-1]))
             with open(final_res_dir, 'wb') as handle:
                 pickle.dump(answers, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
+
 if __name__ == '__main__':
-    
+
     # set up arguments
-    dataset_names, dataset_split, hf_dataset_name, prompt_types, model_name, hf_model_name, load_in_4bit, load_in_8bit, use_20_fewshot, half, prompt_dir, res_dir, cache_dir = setup()
+    dataset_names, dataset_split, hf_dataset_name, prompt_types, model_name, hf_model_name, \
+        load_in_4bit, load_in_8bit, use_20_fewshot, partition, prompt_dir, res_dir, cache_dir = setup()
 
     # get the model
     model, tokenizer = load_model(hf_model_name, load_in_4bit, load_in_8bit, cache_dir)
 
     # run inference
-    run_inference(dataset_names, dataset_split, hf_dataset_name, prompt_types, model_name, half, use_20_fewshot, model, tokenizer, prompt_dir, res_dir)
+    run_inference(
+        dataset_names,
+        dataset_split,
+        hf_dataset_name,
+        prompt_types,
+        model_name,
+        partition,
+        use_20_fewshot,
+        model,
+        tokenizer,
+        prompt_dir,
+        res_dir
+    )

--- a/model/run_hf_remote.py
+++ b/model/run_hf_remote.py
@@ -1,5 +1,5 @@
 # imports and directory setup
-from data_loader import create_data, DatasetName, PromptType
+from data_loader import create_data, DatasetName, ModelName, PromptType
 
 import datasets
 from huggingface_hub.hf_api import HfFolder
@@ -36,9 +36,9 @@ def setup():
     parser.add_argument(
         "--model_name",
         '-m',
-        type=str,
+        type=enum_type(ModelName),
         help="(Nick)name of the model in directory",
-        default="llama 7b",
+        default=ModelName.llama_7b
     )
     parser.add_argument(
         "--model_name_hf",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datasets==2.14.0
+datasets==2.14.6
 huggingface_hub==0.23.0
 matplotlib==3.7.2
 numpy==1.25.1

--- a/scripts/model.sh
+++ b/scripts/model.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-model_name="llama 7b" # model nickname (for saving in folders)
-model_name_hf="meta-llama/Llama-2-7b-hf" # huggingface directory
+model_name="phi 2" # model nickname (for saving in folders)
+model_name_hf="microsoft/phi-2" # huggingface directory
 
 # list of experiments
 # see all possible experiments in: /mcqa-artifacts/model/data_loader.py
@@ -25,7 +25,7 @@ use_20_fewshot="False" # use a 20-shot prompt in ARC? ("False" or "True") => we 
 
 res_dir="/mcqa-artifacts/results/" # Results folder directory
 prompt_dir="/mcqa-artifacts/prompts/" # Prompt folder directory
-cache_dir="" # Cache directory to save the model
+cache_dir="/mcqa-artifacts/cache/" # Cache directory to save the model
 
 datasets_str=$(IFS=" "; echo "${datasets[*]}")
 experiments_str=$(IFS=" "; echo "${experiments[*]}")

--- a/scripts/model_remote.sh
+++ b/scripts/model_remote.sh
@@ -10,6 +10,9 @@ experiments=("normal" "artifact_choices_cot")
 # list of datasets to test
 # see all possible datasets in: /mcqa-artifacts/model/data_loader.py
 datasets=("ARC")
+train_dataset_split="train"
+eval_dataset_split="test"
+hf_dataset_name="nbalepur/mcqa_artifacts"
 
 # what partition of the dataset to run
 # can be "full" or in halves (e.g. "first_half"), quarters (e.g. "first_quarter"), or eigths (e.g. "first_eighth")
@@ -20,11 +23,9 @@ load_in_8bit="False" # load the model in 8bit? ("False" or "True")
 load_in_4bit="False" # load the model in 4bit? ("False" or "True")
 use_20_fewshot="False" # use a 20-shot prompt in ARC? ("False" or "True") => we set this to "True" for Falcon 
 
-res_dir=".../mcqa-artifacts/results" # Results folder directory
-prompt_dir=".../mcqa-artifacts/prompts" # Prompt folder directory
-cache_dir=... # Cache directory to save the model
-
-
+res_dir="/mcqa-artifacts/results/" # Results folder directory
+prompt_dir="/mcqa-artifacts/prompts/" # Prompt folder directory
+cache_dir="/mcqa-artifacts/cache/" # Cache directory to save the model
 
 datasets_str=$(IFS=" "; echo "${datasets[*]}")
 experiments_str=$(IFS=" "; echo "${experiments[*]}")
@@ -34,6 +35,9 @@ python3 /mcqa-artifacts/model/run_hf_remote.py \
 --model_name="$model_name" \
 --model_name_hf="$model_name_hf" \
 --dataset_name="$datasets_str" \
+--train_dataset_split="$train_dataset_split" \
+--eval_dataset_split="$eval_dataset_split" \
+--hf_dataset_name="$hf_dataset_name" \
 --hf_token="$hf_token" \
 --load_in_4bit="$load_in_4bit" \
 --load_in_8bit="$load_in_8bit" \


### PR DESCRIPTION
Changes:
- run_hf / run_hf_remote changes:
  - fix argparse
  - add required options in model_remote.sh
  - clean code
  - add more directories to .gitignore
  - upgrade hf datasets to 2.14.6 to avoid [fsspec error](https://medium.com/@talhatayyab313/notimplementederror-loading-a-dataset-cached-in-a-localfilesystem-is-not-supported-f909126ee7f1)

- plot_accuracy changes:
  - Add arparse to plot_accuracy.py
  - Add main block to plot_accuracy.py
  - Add Enum for model names in data_loader.py
  - Update run_hf.py and run_hf_remote.py to accept Enum type instead of str for model name

Environment:
  - Tested on Google Colab  - T4 GPU runtime (python 3.10.12)

Results:
  - Able to run inference on multiple datasets (ARC, MMLU, HellaSwag) with one model - phi2
<img width="506" alt="image" src="https://github.com/user-attachments/assets/e5d3406c-e2b1-4d8c-9031-aab6668f7ad1">

  - Running inference on multiple datasets with one model is possible
  - Running inference on multiple datasets with multiple models is not supported yet
  - Accuracy plot generated for ARC - phi2 results

![plot_accuracy](https://github.com/user-attachments/assets/cd32408c-4288-4e33-8404-41443a93f8dd)
